### PR TITLE
Refactor repositories to use JPA native queries

### DIFF
--- a/recipe-app-back-end/src/integrationTest/kotlin/nl/rmspek/recipes/controller/api/RecipeControllerIntegrationTest.kt
+++ b/recipe-app-back-end/src/integrationTest/kotlin/nl/rmspek/recipes/controller/api/RecipeControllerIntegrationTest.kt
@@ -141,11 +141,11 @@ class RecipeControllerIntegrationTest(
         listOf(
             "stuk",
             "portie",
-            "g",
+            "gram",
             "cup",
             "ml",
-            "theelepel",
-            "eetlepel",
+            "tsp",
+            "tbsp",
         ).forEach { unit ->
             createRecipe(
                 defaultRecipeView(name = "recipe-$unit").also { recipeView ->
@@ -239,7 +239,7 @@ class RecipeControllerIntegrationTest(
             dbRecipe.id!!,
             dbRecipe.fromDb().also {
                 it.ingredients.clear()
-                it.ingredients += RecipeIngredientView(i1.id!!, i1.name, 14, "g")
+                it.ingredients += RecipeIngredientView(i1.id!!, i1.name, 14, "gram")
             }
         ).andExpect(status().isOk)
 

--- a/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/controller/api/validation/IngredientControllerValidations.kt
+++ b/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/controller/api/validation/IngredientControllerValidations.kt
@@ -10,7 +10,7 @@ fun validatePersistIngredient(
     ingredientView: IngredientView,
     ingredientRepository: IngredientRepository
 ) {
-    if (ingredientRepository.ingredientByName(ingredientView.name) != null) {
+    if (ingredientRepository.findFirstByName(ingredientView.name) != null) {
         throw ResponseStatusException(
             HttpStatus.UNPROCESSABLE_ENTITY,
             "Recipe with name ${ingredientView.name} already exists"

--- a/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/controller/api/validation/RecipeControllerValidations.kt
+++ b/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/controller/api/validation/RecipeControllerValidations.kt
@@ -1,6 +1,5 @@
 package nl.rmspek.recipes.service.controller.api.validation
 
-import nl.rmspek.recipes.model.persistence.parseAmountType
 import nl.rmspek.recipes.model.persistence.representationMap
 import nl.rmspek.recipes.model.rest.RecipeView
 import nl.rmspek.recipes.service.persistence.IngredientRepository
@@ -13,7 +12,7 @@ fun validatePersistRecipe(
     recipeRepository: RecipeRepository,
     ingredientRepository: IngredientRepository
 ) {
-    val recipeByName = recipeRepository.recipeByName(recipeView.name)
+    val recipeByName = recipeRepository.findFirstByName(recipeView.name)
     if (recipeByName != null && recipeByName.id != recipeView.id) {
         throw ResponseStatusException(
             HttpStatus.UNPROCESSABLE_ENTITY,

--- a/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/persistence/IngredientRepository.kt
+++ b/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/persistence/IngredientRepository.kt
@@ -1,11 +1,9 @@
 package nl.rmspek.recipes.service.persistence
 
 import nl.rmspek.recipes.model.persistence.Ingredient
-import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 
 interface IngredientRepository : CrudRepository<Ingredient, Long> {
-    @Query("SELECT * FROM ingredients WHERE name = :name LIMIT 1", nativeQuery = true)
-    fun ingredientByName(@Param("name") name: String): Ingredient?
+    fun findFirstByName(@Param("name") name: String): Ingredient?
 }

--- a/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/persistence/RecipeRepository.kt
+++ b/recipe-app-back-end/src/main/kotlin/nl/rmspek/recipes/service/persistence/RecipeRepository.kt
@@ -1,20 +1,23 @@
 package nl.rmspek.recipes.service.persistence
 
 import nl.rmspek.recipes.model.persistence.Recipe
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 
 interface RecipeRepository : CrudRepository<Recipe, Long> {
-    @Query("SELECT * FROM recipes WHERE name = :name LIMIT 1", nativeQuery = true)
-    fun recipeByName(@Param("name")name: String): Recipe?
+    @EntityGraph(attributePaths = ["ingredients"])
+    override fun findAll(): List<Recipe>
+
+    fun findFirstByName(@Param("name")name: String): Recipe?
 
     @Query("""
-        SELECT *
-        FROM recipes r
-        LEFT JOIN recipe_ingredient ri ON ri.recipe_id = r.id
-        WHERE ri.ingredient_id = :ingredientId
-    """, nativeQuery = true)
+        SELECT r
+        FROM Recipe r
+        JOIN r.ingredients i
+        WHERE i.ingredient.id = :ingredientId
+    """)
     fun byIngredientId(
         @Param("ingredientId") ingredientId: Long,
     ): List<Recipe>


### PR DESCRIPTION
My own inexperience with JPA made me use mysql native queries, for optimization. It is now fully native JPA with entitygraphs to eagerly load dependencies *or* to limit to 1 result.