### PR TITLE
Ensure gradle files work across linux/windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 FROM eclipse-temurin:17-jdk AS backend-builder
 WORKDIR /app
 COPY recipe-app-back-end ./
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
 RUN ./gradlew build
 
 # Stage 3: Final production container


### PR DESCRIPTION

On some windows machines the line endings were messing up when building a docker image
On some windows machines the gradle wrapper could not run because the +x flag does not persist through the windows file system