### PR TITLE
182 diacritics filter

### DIFF
--- a/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
+++ b/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
@@ -102,6 +102,15 @@ describe('Edit Recipe Page', () => {
             })
          })
 
+         it("filters the autocomplete list to a partially match when entering an ingredient with diacritics", () => {
+            cy.dataTest("ingredient-edit-row-0").within(() => {
+               cy.dataTest("ingredient-name").click()
+               cy.dataTest("ingredient-name").clear().type(`Bötèr`)
+               cy.dataTest("autocomplete-option").should("contain", "Boter")
+               cy.dataTest("add-ingredient-option").should("contain", "+ Add Bötèr")
+            })
+         })
+
          it("filters the autocomplete list to multiple existing results when typing in ingredient name field", () => {
             cy.dataTest("ingredient-edit-row-0").within(() => {
                cy.dataTest("ingredient-name").click()

--- a/recipe-app-front-end/cypress/e2e/ingredientspage.cy.js
+++ b/recipe-app-front-end/cypress/e2e/ingredientspage.cy.js
@@ -97,7 +97,7 @@ describe("Ingredients Page", () => {
          cy.intercept('GET', '/api/ingredient', { fixture: 'all-ingredients.json' })
       })
 
-      const searchTerms = ['okono', 'Okono', "OKONO", "Okonomiyaki"]
+      const searchTerms = ['okono', 'Okono', "OKONO", "Okonomiyaki", "ókônomìyakï"]
       searchTerms.forEach((term) => {
          it(`returns 'Okonomiyakisaus' when searching ${term}`, () => {
             cy.dataTest('search-bar').type(term)

--- a/recipe-app-front-end/cypress/e2e/recipelistpage.cy.js
+++ b/recipe-app-front-end/cypress/e2e/recipelistpage.cy.js
@@ -61,7 +61,7 @@ describe('Recipe List Page', () => {
   })
 
   describe("Searchbar", () => {
-    const searchTerms = ['okono', 'Okono', "OKONO", "Okonomiyaki"]
+    const searchTerms = ['okono', 'Okono', "OKONO", "Okonomiyaki", "ókônõmìyakï"]
     searchTerms.forEach((term) => {
       it(`returns Okonomiyaki when searching ${term}`, () => {
         cy.dataTest('search-bar').type(term)

--- a/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
+++ b/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
@@ -7,14 +7,14 @@ import { useConfirm } from "@components/common/ConfirmProvider"
 export default function RecipeIngredientSelector({ ingredient, row, allIngredients, ingredientList, handleIngredientChange, fetchIngredients }) {
 
    const confirm = useConfirm()
-   const [query, setQuery] = useState("")
+   const [searchQuery, setSearchQuery] = useState("")
    const [isOpen, setIsOpen] = useState(false)
    const [isSelectingFromDropdown, setIsSelectingFromDropdown] = useState(false)
    const [hasError, setHasError] = useState(false)
 
    const handleFocus = () => {
       setIsOpen(true)
-      setQuery(ingredient.name)
+      setSearchQuery(ingredient.name)
    }
 
    const handleBlur = (inputfield) => {
@@ -27,7 +27,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
             return
          }
       }
-      setQuery("")
+      setSearchQuery("")
       setIsOpen(false)
       setHasError(false)
       setIsSelectingFromDropdown(false)
@@ -72,7 +72,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
                      handleIngredientChange(row, "name", newIngredient)
                   }
                   setHasError(false)
-                  setQuery("")
+                  setSearchQuery("")
                })
                .catch((error) => {
                   console.error("Error adding ingredient:", error)
@@ -81,8 +81,10 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
          })
    }
 
+   const toBaseChars = (str) => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+
    const filteredIngredients = allIngredients.filter(i =>
-      i.name.toLowerCase().includes(query.toLowerCase()) &&
+      toBaseChars(i.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase())) &&
       !ingredientList.some(ingredient => ingredient.id === i.id)
    )
 
@@ -93,7 +95,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
             value={ingredient.name}
             onChange={(e) => {
                handleIngredientChange(row, "name", e.target.value)
-               setQuery(e.target.value)
+               setSearchQuery(e.target.value)
 
                if (e.target.value.trim() === "") {
                   setHasError(false)
@@ -118,16 +120,16 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
                   </li>
                ))}
                {!allIngredients.some(
-                  (item) => item.name.toLowerCase() === query.toLowerCase()
+                  (item) => item.name.toLowerCase() === searchQuery.toLowerCase()
                ) && (
                      <li data-test="add-ingredient-option" className="add-new-ingredient"
                         onMouseDown={(e) => {
                            setIsSelectingFromDropdown(true)
                            e.preventDefault()
-                           handleQueryIngredientAdd(query)
+                           handleQueryIngredientAdd(searchQuery)
                            setIsOpen(false)
                         }}>
-                        + Add <i>{query}</i>
+                        + Add <i>{searchQuery}</i>
                      </li>
                   )
                }

--- a/recipe-app-front-end/src/components/IngredientsList/IngredientsList.js
+++ b/recipe-app-front-end/src/components/IngredientsList/IngredientsList.js
@@ -4,8 +4,11 @@ import UsedInModal from "./UsedInModal"
 
 export default function IngredientsList({ ingredients, searchQuery, onIngredientEdit, onIngredientDelete }) {
 
-   const filteredIngredients = ingredients.filter((ingredient) =>
-      ingredient.name.toLowerCase().includes(searchQuery.toLowerCase()))
+   const toBaseChars = (str) => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+
+   const filteredIngredients = ingredients.filter(i =>
+      toBaseChars(i.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase())) 
+   )
 
    const [selectedIngredient, setSelectedIngredient] = useState(null)
 

--- a/recipe-app-front-end/src/components/RecipeList/RecipeList.js
+++ b/recipe-app-front-end/src/components/RecipeList/RecipeList.js
@@ -2,8 +2,10 @@ import Link from 'next/link'
 
 export default function RecipeList({ recipes, searchQuery }) {
 
+   const toBaseChars = (str) => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+
     const filteredRecipes = recipes.filter((recipe) =>
-        recipe.name.toLowerCase().includes(searchQuery.toLowerCase()))
+        toBaseChars(recipe.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase())))
 
     return (
         <div className="list">


### PR DESCRIPTION
Closes #182 

Currently when trying to search for recipes/ingredients with diacritics, it wouldn't be able to match existing types with/without diacritics with the search.

It can now.
For the creation of new ingredients via the autocomplete dropdown, it still gives you the option to create a new one, in case the diacritics make it a different ingredient.