### PR TITLE
183 ingredient selected

### DIFF
--- a/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
+++ b/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
@@ -121,7 +121,7 @@ describe('Edit Recipe Page', () => {
             cy.dataTest("ingredient-name").should("have.value", "Tomatenblokjes")
          })
 
-         it.only("identical ingredients in the recipe are recognizable in the dropdown and not allowed to be selected", () => {
+         it("identical ingredients in the recipe are recognizable in the dropdown and not allowed to be selected", () => {
             const alertStub = cy.stub()
             cy.on('window:alert', alertStub)
 

--- a/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
+++ b/recipe-app-front-end/cypress/e2e/editrecipe.cy.js
@@ -111,6 +111,31 @@ describe('Edit Recipe Page', () => {
             })
          })
 
+         it("selecting previous selected ingredient in this field is recognizable and allowed", () => {
+            cy.dataTest("ingredient-edit-row-0").within(() => {
+               cy.dataTest("ingredient-name").click()
+               cy.dataTest("autocomplete-option").should("contain", "Tomatenblokjes").click()
+               cy.dataTest("autocomplete-option").should("have.class", "selected")
+               cy.dataTest("add-ingredient-option").should("not.exist")
+            })
+            cy.dataTest("ingredient-name").should("have.value", "Tomatenblokjes")
+         })
+
+         it.only("identical ingredients in the recipe are recognizable in the dropdown and not allowed to be selected", () => {
+            const alertStub = cy.stub()
+            cy.on('window:alert', alertStub)
+
+            cy.dataTest("ingredient-edit-row-1").within(() => {
+               cy.dataTest("ingredient-name").click().clear().type("Tomatenblokjes")
+               cy.dataTest("autocomplete-option").should("contain", "Tomatenblokjes").should("have.class", "occurs").click().then(() => {
+                  expect(alertStub).to.have.been.calledOnce
+                  expect(alertStub).to.have.been.calledWith("Ingredient is already used in this recipe.")
+               })
+               cy.dataTest("ingredient-name").should("be.empty").should("have.focus")
+               })
+               cy.get(".autocomplete-dropdown").should("exist").should("contain", "Aardappel").and("contain", "Bleekselderij").and("contain", "Boter")
+         })
+
          it("filters the autocomplete list to multiple existing results when typing in ingredient name field", () => {
             cy.dataTest("ingredient-edit-row-0").within(() => {
                cy.dataTest("ingredient-name").click()

--- a/recipe-app-front-end/src/app/globals.css
+++ b/recipe-app-front-end/src/app/globals.css
@@ -11,6 +11,7 @@
   --accent-background-color: #fffefb;
   --accent-text: #fffefb;
   --text-color: #333;
+  --text-color-light: #929292;
   --placeholder-color: #75777a;
   --font-main: 'Inter', sans-serif;
 }
@@ -468,12 +469,13 @@ textarea.note-details {
   transition: background-color 0.2s ease;
 }
 
-.selected{
+.autocomplete-dropdown .selected{
   font-style: italic;
+  background-color: var(--hoover-color)
 }
 
 .occurs{
-  color: var(--primary-accent);
+  color: var(--text-color-light);
   font-style: italic;
 }
 

--- a/recipe-app-front-end/src/app/globals.css
+++ b/recipe-app-front-end/src/app/globals.css
@@ -468,6 +468,10 @@ textarea.note-details {
   transition: background-color 0.2s ease;
 }
 
+.selected{
+  font-style: italic;
+}
+
 .dropdown-label {
   width: 100%;
 }

--- a/recipe-app-front-end/src/app/globals.css
+++ b/recipe-app-front-end/src/app/globals.css
@@ -472,6 +472,11 @@ textarea.note-details {
   font-style: italic;
 }
 
+.occurs{
+  color: var(--primary-accent);
+  font-style: italic;
+}
+
 .dropdown-label {
   width: 100%;
 }

--- a/recipe-app-front-end/src/components/EditRecipe/EditRecipeIngredientList.js
+++ b/recipe-app-front-end/src/components/EditRecipe/EditRecipeIngredientList.js
@@ -13,7 +13,7 @@ export default function EditRecipeIngredientsList({ ingredientList, handleIngred
             </div>
 
             {ingredientList.map((ingredient, index) => (
-                <div data-test={`ingredient-edit-row-${index}`} className="row" key={ingredient.id}>
+                <div data-test={`ingredient-edit-row-${index}`} className="row" key={`${ingredient.id}-${index}`}>
                     <RecipeIngredientSelector ingredient={ingredient} row={index} allIngredients={allIngredients} ingredientList={ingredientList} handleIngredientChange={handleIngredientChange} fetchIngredients={fetchIngredients} />
                     <input
                         data-test="ingredient-amount" className="second-column ingredient-input" type="text" placeholder="quanity"

--- a/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
+++ b/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
@@ -84,8 +84,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
 
 
    const filteredIngredients = allIngredients.filter(i =>
-      toBaseChars(i.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase())) &&
-      !ingredientList.some(ingredient => ingredient.id === i.id)
+      toBaseChars(i.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase()))
    )
 
    return (
@@ -107,18 +106,22 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
          />
          {isOpen && (
             <ul className="autocomplete-dropdown ingredient-input">
-               {filteredIngredients.map((option) => (
-                  <li data-test="autocomplete-option" key={option.id}
-                     onMouseDown={(e) => {
-                        setIsSelectingFromDropdown(true)
-                        e.preventDefault()
-                        handleIngredientChange(row, "name", option.name)
-                        handleIngredientChange(row, "id", option.id)
-                        setHasError(false)
-                     }}>
-                     {option.name}
-                  </li>
-               ))}
+               {filteredIngredients.map((option, index) => {
+                  const isSelected = ingredientList.some(ingredient => ingredient.id === option.id)
+
+                  return (
+                     <li data-test="autocomplete-option" key={`${option.id}-${index}`}
+                     className= {isSelected ? 'selected' : ''}
+                        onMouseDown={(e) => {
+                           setIsSelectingFromDropdown(true)
+                           e.preventDefault()
+                           handleIngredientChange(row, "name", option.name)
+                           handleIngredientChange(row, "id", option.id)
+                           setHasError(false)
+                        }}>
+                        {option.name}
+                     </li>)
+               })}
                {!allIngredients.some(
                   (item) => item.name.toLowerCase() === searchQuery.toLowerCase()
                ) && (

--- a/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
+++ b/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
@@ -120,6 +120,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
                            if (occursInRecipe) {
                               alert("Ingredient is already used in this recipe.")
                               handleIngredientChange(row, "name", "")
+                              setSearchQuery("")
                               inputRef.current.focus()
                               return
                            }

--- a/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
+++ b/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { addIngredient } from "@components/common/Apicalls"
 import { useConfirm } from "@components/common/ConfirmProvider"
 import { toBaseChars } from "@components/common/filterHelpers"
@@ -12,6 +12,7 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
    const [isOpen, setIsOpen] = useState(false)
    const [isSelectingFromDropdown, setIsSelectingFromDropdown] = useState(false)
    const [hasError, setHasError] = useState(false)
+   const inputRef = useRef(null)
 
    const handleFocus = () => {
       setIsOpen(true)
@@ -87,7 +88,10 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
 
    return (
       <div className="first-column autocomplete-container">
-         <input data-test={`ingredient-name`} className={`autocomplete-input ${hasError ? 'error' : ''}`}
+         <input
+            ref={inputRef}
+            data-test={`ingredient-name`}
+            className={`autocomplete-input ${hasError ? 'error' : ''}`}
             type="text"
             value={ingredient.name}
             onChange={(e) => {
@@ -112,12 +116,14 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
                      <li data-test="autocomplete-option" key={`${option.id}-${index}`}
                         className={`${isSelected ? 'selected' : ''} ${occursInRecipe ? 'occurs' : ''}`}
                         onMouseDown={(e) => {
+                           e.preventDefault()
                            if (occursInRecipe) {
                               alert("Ingredient is already used in this recipe.")
+                              handleIngredientChange(row, "name", "")
+                              inputRef.current.focus()
                               return
                            }
                            setIsSelectingFromDropdown(true)
-                           e.preventDefault()
                            handleIngredientChange(row, "name", option.name)
                            handleIngredientChange(row, "id", option.id)
                            setHasError(false)

--- a/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
+++ b/recipe-app-front-end/src/components/EditRecipe/RecipeIngredientSelector.js
@@ -19,7 +19,6 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
    }
 
    const handleBlur = (inputfield) => {
-
       if (inputfield.target.value.trim() !== "") {
          if (!isSelectingFromDropdown && !validateIngredient(ingredient)) {
             setHasError(true)
@@ -82,7 +81,6 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
          })
    }
 
-
    const filteredIngredients = allIngredients.filter(i =>
       toBaseChars(i.name.toLowerCase()).includes(toBaseChars(searchQuery.toLowerCase()))
    )
@@ -107,12 +105,17 @@ export default function RecipeIngredientSelector({ ingredient, row, allIngredien
          {isOpen && (
             <ul className="autocomplete-dropdown ingredient-input">
                {filteredIngredients.map((option, index) => {
-                  const isSelected = ingredientList.some(ingredient => ingredient.id === option.id)
+                  const occursInRecipe = ingredientList.some((ingredient, index) => ingredient.id === option.id && index !== row)
+                  const isSelected = ingredientList.some((ingredient, index) => ingredient.id === option.id && index === row)
 
                   return (
                      <li data-test="autocomplete-option" key={`${option.id}-${index}`}
-                     className= {isSelected ? 'selected' : ''}
+                        className={`${isSelected ? 'selected' : ''} ${occursInRecipe ? 'occurs' : ''}`}
                         onMouseDown={(e) => {
+                           if (occursInRecipe) {
+                              alert("Ingredient is already used in this recipe.")
+                              return
+                           }
                            setIsSelectingFromDropdown(true)
                            e.preventDefault()
                            handleIngredientChange(row, "name", option.name)


### PR DESCRIPTION
Closes #183 

Changed:
- All the ingredients are always shown in the list
- Ingredients that occur somewhere else in the recipe have a purple italic styling, and are blocked to be selected again
- Ingredients that are selected in this field have a black italic styling and are allowed to be selected within this field.

If you want to select the same ingredient you had selected in that field before, that is possible.
If you want to select an ingredient that is already used, that is not possible.

Not sure yet on the exact styling, but that can easily be changed. 